### PR TITLE
Create default-PR-template.md

### DIFF
--- a/default-PR-template.md
+++ b/default-PR-template.md
@@ -1,0 +1,20 @@
+### All Submissions:
+
+  Have you followed the guildelines in our contributing document?
+  Have you checked to ensure there are not open Pull Requests for the same update/change?
+  
+## New Feature Submissions:
+
+  Does your submission pass tests?
+  Have you lint your code locally prior to submission?
+  
+ ### Changes to Core Features:
+ 
+  Have you added an explanation in pivotal tracker board of what your changes do and why you will like us to include them?
+  Have you written new tests for your core changes as applicable?
+  
+ ### Others
+  
+   Have you made sure you gave a descriptive name to your PR
+   Have you made sure you have only one commit (if not, squash them into one commit).
+   Have you made sure your branch name match our naming convention check. https://github.com/andela/bestpractices/wiki/Git-naming-conventions-and-best-practices


### PR DESCRIPTION
### Description
 This is PR-template to guide contributing developers as to the standard expected when creating a pull request.